### PR TITLE
Fix wrong calculation of powered values

### DIFF
--- a/src/main/java/com/accelad/math/doubledouble/DoubleDouble.java
+++ b/src/main/java/com/accelad/math/doubledouble/DoubleDouble.java
@@ -1,9 +1,9 @@
 package com.accelad.math.doubledouble;
 
+import java.io.Serializable;
+
 import com.google.common.base.Objects;
 import com.google.common.math.DoubleMath;
-
-import java.io.Serializable;
 
 public strictfp class DoubleDouble implements Serializable, Comparable<DoubleDouble>, Cloneable {
 
@@ -849,7 +849,7 @@ public strictfp class DoubleDouble implements Serializable, Comparable<DoubleDou
     public DoubleDouble pow(DoubleDouble x) {
         DoubleDoubleCache<DoubleDouble> map = POW_DOUBLE_DOUBLE_CACHE.get(hi, lo,
                 DoubleDoubleCache::new);
-        return map.get(hi, lo, () -> innerPow(x));
+        return map.get(x.hi, x.lo, () -> innerPow(x));
     }
 
     private DoubleDouble innerPow(DoubleDouble x) {

--- a/src/test/java/com/accelad/math/doubledouble/DoubleDoubleTest.java
+++ b/src/test/java/com/accelad/math/doubledouble/DoubleDoubleTest.java
@@ -1,5 +1,7 @@
 package com.accelad.math.doubledouble;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -11,6 +13,19 @@ import org.junit.Test;
 import com.google.common.collect.ImmutableMap;
 
 public class DoubleDoubleTest {
+
+    @Test
+    public void should_return_the_correct_value_when_given_value_is_powered_by_two_and_then_powered_by_three()
+            throws Exception {
+        DoubleDouble givenValue = DoubleDouble.fromString("1.2");
+        DoubleDouble two = DoubleDouble.fromString("2");
+        DoubleDouble givenValuePoweredByTwo = givenValue.pow(two);
+        assertThat(givenValuePoweredByTwo, is(DoubleDouble.fromString("1.44")));
+
+        DoubleDouble three = DoubleDouble.fromString("3");
+        DoubleDouble givenValuePoweredByThree = givenValue.pow(three);
+        assertThat(givenValuePoweredByThree, is(DoubleDouble.fromString("1.728")));
+    }
 
     @Test
     public void test1() throws Exception {


### PR DESCRIPTION
When a value was powered two times with different power values, the
second computed value was wrong.

The reason was an incorrect request in the cache.