### PR TITLE
Fix DoubleDouble toString representation

### DIFF
--- a/src/main/java/com/accelad/math/doubledouble/DoubleDouble.java
+++ b/src/main/java/com/accelad/math/doubledouble/DoubleDouble.java
@@ -1,9 +1,12 @@
 package com.accelad.math.doubledouble;
 
-import java.io.Serializable;
-
 import com.google.common.base.Objects;
 import com.google.common.math.DoubleMath;
+
+import java.io.Serializable;
+import java.math.BigDecimal;
+import java.math.MathContext;
+import java.math.RoundingMode;
 
 public strictfp class DoubleDouble implements Serializable, Comparable<DoubleDouble>, Cloneable {
 
@@ -1175,7 +1178,14 @@ public strictfp class DoubleDouble implements Serializable, Comparable<DoubleDou
 
     @Override
     public String toString() {
-        return Double.toString(doubleValue());
+        BigDecimal hiPart = new BigDecimal(hi);
+        BigDecimal loPart = new BigDecimal(lo);
+        int numberOfSignificantDigits = 30;
+        MathContext roundingContextAt30Digits = new MathContext(numberOfSignificantDigits, RoundingMode.HALF_UP);
+        return hiPart.add(loPart)
+                .round(roundingContextAt30Digits)
+                .stripTrailingZeros()
+                .toPlainString();
     }
 
     public DoubleDouble trunc() {

--- a/src/test/java/com/accelad/math/doubledouble/DoubleDoubleTest.java
+++ b/src/test/java/com/accelad/math/doubledouble/DoubleDoubleTest.java
@@ -1,16 +1,15 @@
 package com.accelad.math.doubledouble;
 
+import com.google.common.collect.ImmutableMap;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Map.Entry;
+
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-
-import java.util.Map.Entry;
-
-import org.junit.Assert;
-import org.junit.Test;
-
-import com.google.common.collect.ImmutableMap;
 
 public class DoubleDoubleTest {
 
@@ -67,6 +66,16 @@ public class DoubleDoubleTest {
     public void testToString() throws Exception {
         DoubleDouble dd = DoubleDouble.fromOneDouble(4.75);
         Assert.assertEquals("4.75", dd.toString());
+    }
+
+    @Test
+    public void should_return_the_correct_precise_string_representation_when_value_is_30_digits_precise() throws Exception {
+        String expectedString = "0.12345678901234567890123456789";
+        DoubleDouble parsedValue = DoubleDouble.fromString(expectedString);
+
+        String returnedValuesAsString = parsedValue.toString();
+
+        assertEquals(expectedString, returnedValuesAsString);
     }
 
     @Test


### PR DESCRIPTION
The previous toString representation was not showing the full precision of the doubledouble.

Now it displays the full 30 digits (trailing zeroes are not shown)