### PR TITLE
Fix doubledouble equality check

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,13 @@
             <version>4.12</version>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.apfloat</groupId>
+            <artifactId>apfloat</artifactId>
+            <version>1.8.3</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <licenses>

--- a/src/main/java/com/accelad/math/doubledouble/DoubleDouble.java
+++ b/src/main/java/com/accelad/math/doubledouble/DoubleDouble.java
@@ -227,6 +227,19 @@ public strictfp class DoubleDouble implements Serializable, Comparable<DoubleDou
         return s;
     }
 
+    public static DoubleDouble atan2(DoubleDouble x, DoubleDouble y) {
+        if (x.signum() == 0) {
+            if (y.signum() == 0) throw new ArithmeticException("Angle of (0, 0)");
+            else if (y.signum() > 0) return PI_2;
+            else return PI_2.negate();
+        } else if (x.signum() > 0) {
+            return y.divide(x).atan();
+        } else {
+            if (y.signum() >= 0) return y.divide(x).atan().add(PI);
+            else return y.divide(x).atan().subtract(PI);
+        }
+    }
+
     public DoubleDouble atan() {
         if (isNaN) {
             return NaN;

--- a/src/main/java/com/accelad/math/doubledouble/DoubleDouble.java
+++ b/src/main/java/com/accelad/math/doubledouble/DoubleDouble.java
@@ -1,7 +1,6 @@
 package com.accelad.math.doubledouble;
 
 import com.google.common.base.Objects;
-import com.google.common.math.DoubleMath;
 
 import java.io.Serializable;
 import java.math.BigDecimal;
@@ -50,6 +49,7 @@ public strictfp class DoubleDouble implements Serializable, Comparable<DoubleDou
     public static final DoubleDouble TWO = fromOneDouble(2.0);
     private static final DoubleDouble TEN = fromOneDouble(10.0);
     private static final DoubleDouble LOG_TEN = TEN.log();
+    private static final DoubleDouble TWENTY_NINE_DIGIT_VALUE = DoubleDouble.fromOneDouble(1E29);
 
     public static DoubleDouble fromString(String str) {
         int i = 0;
@@ -227,7 +227,7 @@ public strictfp class DoubleDouble implements Serializable, Comparable<DoubleDou
         return s;
     }
 
-    public static DoubleDouble atan2(DoubleDouble x, DoubleDouble y) {
+    public static DoubleDouble atan2(DoubleDouble y, DoubleDouble x) {
         if (x.signum() == 0) {
             if (y.signum() == 0) throw new ArithmeticException("Angle of (0, 0)");
             else if (y.signum() > 0) return PI_2;
@@ -1220,9 +1220,13 @@ public strictfp class DoubleDouble implements Serializable, Comparable<DoubleDou
     @Override
     public boolean equals(Object object) {
         if (object instanceof DoubleDouble) {
-            DoubleDouble that = (DoubleDouble) object;
-            return DoubleMath.fuzzyEquals(hi, that.hi, 1E-12) && DoubleMath.fuzzyEquals(lo, that.lo,
-                    1E-12);
+            DoubleDouble other = (DoubleDouble) object;
+
+            if (other.hi == this.hi && other.lo == this.lo) return true;
+
+            DoubleDouble criteria = other.divide(TWENTY_NINE_DIGIT_VALUE).abs();
+            boolean lowerThan = other.subtract(this).abs().lt(criteria);
+            return lowerThan;
         }
         return false;
     }

--- a/src/main/java/com/accelad/math/nilgiri/AbstractFactory.java
+++ b/src/main/java/com/accelad/math/nilgiri/AbstractFactory.java
@@ -4,6 +4,7 @@ package com.accelad.math.nilgiri;
 public interface AbstractFactory<X extends Field<X>>
         extends AbstractIdentityFactory<X> {
 
+    X val(String valueAsString);
     X val(double i_v);
 
     X abs(X i_x);

--- a/src/main/java/com/accelad/math/nilgiri/DoubleDoubleComplex.java
+++ b/src/main/java/com/accelad/math/nilgiri/DoubleDoubleComplex.java
@@ -1,7 +1,5 @@
 package com.accelad.math.nilgiri;
 
-import org.apache.commons.math3.util.FastMath;
-
 import com.accelad.math.doubledouble.DoubleDouble;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
@@ -133,8 +131,9 @@ public class DoubleDoubleComplex implements ComplexNumber<DoubleDoubleReal, Doub
     }
 
     public DoubleDoubleComplex log() {
-        return new DoubleDoubleComplex(this.abs().re().log(),
-                new DoubleDoubleReal(FastMath.atan2(imaginary.doubleValue(), real.doubleValue())));
+        DoubleDoubleReal real = this.abs().re().log();
+        DoubleDouble imaginaryPart = DoubleDouble.atan2(this.imaginary.getDoubleDouble(), this.real.getDoubleDouble());
+        return new DoubleDoubleComplex(real, new DoubleDoubleReal(imaginaryPart));
     }
 
     @Override

--- a/src/main/java/com/accelad/math/nilgiri/DoubleDoubleComplexFactory.java
+++ b/src/main/java/com/accelad/math/nilgiri/DoubleDoubleComplexFactory.java
@@ -31,6 +31,11 @@ public class DoubleDoubleComplexFactory
     }
 
     @Override
+    public DoubleDoubleComplex val(String valueAsString) {
+        return new DoubleDoubleComplex(new DoubleDoubleReal(valueAsString));
+    }
+
+    @Override
     public DoubleDoubleComplex val(double value) {
         return new DoubleDoubleComplex(value);
     }

--- a/src/main/java/com/accelad/math/nilgiri/DoubleDoubleRealFactory.java
+++ b/src/main/java/com/accelad/math/nilgiri/DoubleDoubleRealFactory.java
@@ -1,10 +1,9 @@
 package com.accelad.math.nilgiri;
 
-import java.util.Random;
-
 import com.accelad.math.doubledouble.DoubleDouble;
-
 import sun.reflect.generics.reflectiveObjects.NotImplementedException;
+
+import java.util.Random;
 
 public class DoubleDoubleRealFactory implements AbstractFactory<DoubleDoubleReal> {
 
@@ -17,6 +16,11 @@ public class DoubleDoubleRealFactory implements AbstractFactory<DoubleDoubleReal
 
     public static DoubleDoubleRealFactory instance() {
         return m_INSTANCE;
+    }
+
+    @Override
+    public DoubleDoubleReal val(String valueAsString) {
+        return new DoubleDoubleReal(valueAsString);
     }
 
     @Override

--- a/src/main/java/com/accelad/math/nilgiri/DoubleRealFactory.java
+++ b/src/main/java/com/accelad/math/nilgiri/DoubleRealFactory.java
@@ -1,9 +1,6 @@
 package com.accelad.math.nilgiri;
 
-import java.util.Map;
 import java.util.Random;
-
-import sun.reflect.generics.reflectiveObjects.NotImplementedException;
 
 public class DoubleRealFactory implements AbstractFactory<DoubleReal> {
 
@@ -18,6 +15,11 @@ public class DoubleRealFactory implements AbstractFactory<DoubleReal> {
         return m_INSTANCE;
     }
 
+
+    @Override
+    public DoubleReal val(String valueAsString) {
+        return new DoubleReal(valueAsString);
+    }
 
     @Override
     public DoubleReal val(double v) {

--- a/src/test/java/com/accelad/math/doubledouble/DoubleDoubleTest.java
+++ b/src/test/java/com/accelad/math/doubledouble/DoubleDoubleTest.java
@@ -6,13 +6,11 @@ import org.junit.Test;
 
 import java.util.Map.Entry;
 
-import static com.accelad.math.doubledouble.DoubleDouble.ONE;
-import static com.accelad.math.doubledouble.DoubleDouble.PI;
+import static com.accelad.math.doubledouble.DoubleDouble.*;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 public class DoubleDoubleTest {
 
@@ -33,14 +31,14 @@ public class DoubleDoubleTest {
     public void should_throw_an_exception_when_computing_atan2_with_x_and_y_equals_zero() throws Exception {
         DoubleDouble x = DoubleDouble.ZERO;
         DoubleDouble y = DoubleDouble.ZERO;
-        DoubleDouble.atan2(x, y);
+        DoubleDouble.atan2(y, x);
     }
 
     @Test()
     public void should_return_positive_half_PI_when_computing_atan2_with_x_equals_zero_and_y_is_positive() throws Exception {
         DoubleDouble x = DoubleDouble.ZERO;
         DoubleDouble y = ONE;
-        DoubleDouble result = DoubleDouble.atan2(x, y);
+        DoubleDouble result = DoubleDouble.atan2(y, x);
 
         assertThat(result, equalTo(DoubleDouble.PI_2));
     }
@@ -49,7 +47,7 @@ public class DoubleDoubleTest {
     public void should_return_negative_half_PI_when_computing_atan2_with_x_equals_zero_and_y_is_negative() throws Exception {
         DoubleDouble x = DoubleDouble.ZERO;
         DoubleDouble y = ONE.negate();
-        DoubleDouble result = DoubleDouble.atan2(x, y);
+        DoubleDouble result = DoubleDouble.atan2(y, x);
 
         assertThat(result, equalTo(DoubleDouble.PI_2.negate()));
     }
@@ -58,7 +56,7 @@ public class DoubleDoubleTest {
     public void should_return_the_atan_of_y_divided_by_x_when_computing_atan2_with_x_is_positive() throws Exception {
         DoubleDouble x = ONE;
         DoubleDouble y = DoubleDouble.TWO;
-        DoubleDouble result = DoubleDouble.atan2(x, y);
+        DoubleDouble result = DoubleDouble.atan2(y, x);
         DoubleDouble expected = y.divide(x).atan();
 
         assertThat(result, equalTo(expected));
@@ -68,7 +66,7 @@ public class DoubleDoubleTest {
     public void should_return_PI_plus_the_atan_of_y_divided_by_x_when_computing_atan2_with_x_is_negative_and_y_is_positive() throws Exception {
         DoubleDouble x = ONE.negate();
         DoubleDouble y = DoubleDouble.TWO;
-        DoubleDouble result = DoubleDouble.atan2(x, y);
+        DoubleDouble result = DoubleDouble.atan2(y, x);
         DoubleDouble expected = y.divide(x).atan().add(PI);
 
         assertThat(result, equalTo(expected));
@@ -78,7 +76,7 @@ public class DoubleDoubleTest {
     public void should_return_the_atan_of_y_divided_by_x_plus_PI_when_computing_atan2_with_x_is_negative_and_y_is_zero() throws Exception {
         DoubleDouble x = ONE.negate();
         DoubleDouble y = DoubleDouble.ZERO;
-        DoubleDouble result = DoubleDouble.atan2(x, y);
+        DoubleDouble result = DoubleDouble.atan2(y, x);
         DoubleDouble expected = y.divide(x).atan().add(PI);
 
         assertThat(result, equalTo(expected));
@@ -88,7 +86,7 @@ public class DoubleDoubleTest {
     public void should_return_the_atan_of_y_divided_by_x_minus_pi_when_computing_atan2_with_x_is_negative_and_y_is_negative() throws Exception {
         DoubleDouble x = ONE.negate();
         DoubleDouble y = DoubleDouble.TWO.negate();
-        DoubleDouble result = DoubleDouble.atan2(x, y);
+        DoubleDouble result = DoubleDouble.atan2(y, x);
         DoubleDouble expected = y.divide(x).atan().subtract(PI);
 
         assertThat(result, equalTo(expected));
@@ -156,7 +154,56 @@ public class DoubleDoubleTest {
         first = DoubleDouble.fromOneDouble(4.75458763958447);
         second = DoubleDouble.fromOneDouble(4.75458763958436);
 
-        assertTrue(first.equals(second));
+        assertFalse(first.equals(second));
+    }
+
+    @Test
+    public void should_return_equals_when_there_is_no_difference_with_30_digit_precise_number() {
+        DoubleDouble first = DoubleDouble.fromString("0.12345678901234567890123456789");
+        DoubleDouble second = DoubleDouble.fromString("0.12345678901234567890123456789");
+
+        assertEquals(first, second);
+    }
+
+
+    @Test
+    public void should_return_not_equals_when_there_is_one_digit_difference_with_30_digit_precise_number() {
+        DoubleDouble first = DoubleDouble.fromString("0.12345678901234567890123456789");
+        DoubleDouble second = DoubleDouble.fromString("0.12345678901234567890123456788");
+
+        assertNotEquals(first, second);
+    }
+
+    @Test
+    public void should_return_not_equals_when_values_are_very_low() {
+        DoubleDouble first = DoubleDouble.fromString("1E-20");
+        DoubleDouble second = DoubleDouble.fromString("1E-21");
+
+        assertNotEquals(first, second);
+    }
+
+    @Test
+    public void should_return_equals_when_equality_in_the_expected_precision_range_is_ok() {
+        DoubleDouble first = DoubleDouble.fromTwoDouble(4.0, 1E-32);
+        DoubleDouble second = DoubleDouble.fromTwoDouble(4.0, 1E-33);
+
+        assertEquals(first, second);
+    }
+
+    @Test
+    public void should_return_equals_when_both_are_zero() {
+        DoubleDouble first = ZERO;
+        DoubleDouble second = ZERO;
+
+        assertEquals(first, second);
+    }
+
+    @Test
+    public void should_not_return_equal_when_one_is_zero_and_the_other_is_low() {
+        DoubleDouble first = ZERO;
+        DoubleDouble second = DoubleDouble.fromString("1E-13");
+
+        assertNotEquals(first, second);
     }
 
     @Test
@@ -172,14 +219,14 @@ public class DoubleDoubleTest {
                 .put(" -1e17", DoubleDouble.fromOneDouble(-1E17))
                 .put(" 1e14", DoubleDouble.fromOneDouble(1E14))
                 .put("+1e14", DoubleDouble.fromOneDouble(1E14))
-                .put("1.0000000399999998E-4", DoubleDouble.fromOneDouble(1.0000000399999998E-4))
-                .put("3.93460376843724", DoubleDouble.fromOneDouble(3.93460376843724))
-                .put("1.0000000299999998E-4", DoubleDouble.fromOneDouble(1.0000000299999998E-4))
-                .put("3.9346037077899485", DoubleDouble.fromOneDouble(3.9346037077899485))
-                .put("1.0000000199999998E-4", DoubleDouble.fromOneDouble(1.0000000199999998E-4))
-                .put("3.934603647142657", DoubleDouble.fromOneDouble(3.934603647142657))
-                .put("1.0000000099999999E-4", DoubleDouble.fromOneDouble(1.0000000099999999E-4))
-                .put("3.9346035864953652", DoubleDouble.fromOneDouble(3.9346035864953652))
+                .put("1.0000000399999998E-4", DoubleDouble.fromTwoDouble(1.0000000399999998E-4, 0.4743564752683E-20))
+                .put("3.93460376843724", DoubleDouble.fromTwoDouble(3.93460376843724, -1.3440350972814486E-16))
+                .put("1.0000000299999998E-4", DoubleDouble.fromTwoDouble(1.0000000299999998E-4, 7.477619529328194E-22))
+                .put("3.9346037077899485", DoubleDouble.fromTwoDouble(3.9346037077899485, -1.2721925158985238E-18))
+                .put("1.0000000199999998E-4", DoubleDouble.fromTwoDouble(1.0000000199999998E-4, -3.248040846817162E-21))
+                .put("3.934603647142657", DoubleDouble.fromTwoDouble(3.934603647142657, 1.3185912469634786E-16))
+                .put("1.0000000099999999E-4", DoubleDouble.fromTwoDouble(1.0000000099999999E-4, 2.7561563534328564E-21))
+                .put("3.9346035864953652", DoubleDouble.fromTwoDouble(3.9346035864953652, -3.50095580914058E-17))
                 .build();
 
         for (Entry<String, DoubleDouble> entry : testData.entrySet()) {

--- a/src/test/java/com/accelad/math/doubledouble/DoubleDoubleTest.java
+++ b/src/test/java/com/accelad/math/doubledouble/DoubleDoubleTest.java
@@ -6,6 +6,9 @@ import org.junit.Test;
 
 import java.util.Map.Entry;
 
+import static com.accelad.math.doubledouble.DoubleDouble.ONE;
+import static com.accelad.math.doubledouble.DoubleDouble.PI;
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
@@ -24,6 +27,71 @@ public class DoubleDoubleTest {
         DoubleDouble three = DoubleDouble.fromString("3");
         DoubleDouble givenValuePoweredByThree = givenValue.pow(three);
         assertThat(givenValuePoweredByThree, is(DoubleDouble.fromString("1.728")));
+    }
+
+    @Test(expected = ArithmeticException.class)
+    public void should_throw_an_exception_when_computing_atan2_with_x_and_y_equals_zero() throws Exception {
+        DoubleDouble x = DoubleDouble.ZERO;
+        DoubleDouble y = DoubleDouble.ZERO;
+        DoubleDouble.atan2(x, y);
+    }
+
+    @Test()
+    public void should_return_positive_half_PI_when_computing_atan2_with_x_equals_zero_and_y_is_positive() throws Exception {
+        DoubleDouble x = DoubleDouble.ZERO;
+        DoubleDouble y = ONE;
+        DoubleDouble result = DoubleDouble.atan2(x, y);
+
+        assertThat(result, equalTo(DoubleDouble.PI_2));
+    }
+
+    @Test()
+    public void should_return_negative_half_PI_when_computing_atan2_with_x_equals_zero_and_y_is_negative() throws Exception {
+        DoubleDouble x = DoubleDouble.ZERO;
+        DoubleDouble y = ONE.negate();
+        DoubleDouble result = DoubleDouble.atan2(x, y);
+
+        assertThat(result, equalTo(DoubleDouble.PI_2.negate()));
+    }
+
+    @Test()
+    public void should_return_the_atan_of_y_divided_by_x_when_computing_atan2_with_x_is_positive() throws Exception {
+        DoubleDouble x = ONE;
+        DoubleDouble y = DoubleDouble.TWO;
+        DoubleDouble result = DoubleDouble.atan2(x, y);
+        DoubleDouble expected = y.divide(x).atan();
+
+        assertThat(result, equalTo(expected));
+    }
+
+    @Test()
+    public void should_return_PI_plus_the_atan_of_y_divided_by_x_when_computing_atan2_with_x_is_negative_and_y_is_positive() throws Exception {
+        DoubleDouble x = ONE.negate();
+        DoubleDouble y = DoubleDouble.TWO;
+        DoubleDouble result = DoubleDouble.atan2(x, y);
+        DoubleDouble expected = y.divide(x).atan().add(PI);
+
+        assertThat(result, equalTo(expected));
+    }
+
+    @Test()
+    public void should_return_the_atan_of_y_divided_by_x_plus_PI_when_computing_atan2_with_x_is_negative_and_y_is_zero() throws Exception {
+        DoubleDouble x = ONE.negate();
+        DoubleDouble y = DoubleDouble.ZERO;
+        DoubleDouble result = DoubleDouble.atan2(x, y);
+        DoubleDouble expected = y.divide(x).atan().add(PI);
+
+        assertThat(result, equalTo(expected));
+    }
+
+    @Test()
+    public void should_return_the_atan_of_y_divided_by_x_minus_pi_when_computing_atan2_with_x_is_negative_and_y_is_negative() throws Exception {
+        DoubleDouble x = ONE.negate();
+        DoubleDouble y = DoubleDouble.TWO.negate();
+        DoubleDouble result = DoubleDouble.atan2(x, y);
+        DoubleDouble expected = y.divide(x).atan().subtract(PI);
+
+        assertThat(result, equalTo(expected));
     }
 
     @Test

--- a/src/test/java/com/accelad/math/nilgiri/AbstractFactoriesTest.java
+++ b/src/test/java/com/accelad/math/nilgiri/AbstractFactoriesTest.java
@@ -1,21 +1,25 @@
 package com.accelad.math.nilgiri;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import org.junit.Test;
 
 import java.util.function.BiFunction;
 
-import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public abstract class AbstractFactoriesTest<X extends Field<X>> {
 
     private final double testEpsilon;
 
-    protected AbstractFactoriesTest(double testEpsilon) {
+    AbstractFactoriesTest(double testEpsilon) {
         this.testEpsilon = testEpsilon;
     }
 
     private X generateVal(double input) {
+        return getFactory().val(input);
+    }
+
+    private X generateVal(String input) {
         return getFactory().val(input);
     }
 
@@ -153,26 +157,26 @@ public abstract class AbstractFactoriesTest<X extends Field<X>> {
 
     @Test
     public void testPwr() {
-        assertEquals(generateVal(0.3535533905932738),
+        assertEquals(generateVal("0.353553390593273762200422181052"),
                 getFactory().pwr(generateVal(0.5), generateVal(1.5)));
-        assertEquals(generateVal(0.3535533905932738),
+        assertEquals(generateVal("0.353553390593273762200422181052"),
                 getFactory().pwr(generateVal(-0.5), generateVal(1.5)));
     }
 
     @Test
     public void testPwrs() {
-        assertEquals(generateVal(0.3535533905932738),
+        assertEquals(generateVal("0.353553390593273762200422181052"),
                 getFactory().pwr(generateVal(0.5), generateVal(1.5)));
-        assertEquals(generateVal(-0.3535533905932738),
+        assertEquals(generateVal("-0.353553390593273762200422181052"),
                 getFactory().pwrs(generateVal(-0.5), generateVal(1.5)));
     }
 
     @Test
     public void testHypot() {
         assertEquals(
-                generateVal(5.6568542494923810), getFactory().hypot(generateVal(4), generateVal(4)));
+                generateVal("5.65685424949238019520675489684"), getFactory().hypot(generateVal(4), generateVal(4)));
         assertEquals(
-                generateVal(2.8284271247461903), getFactory().hypot(generateVal(2), generateVal(2)));
+                generateVal("2.82842712474619009760337744842"), getFactory().hypot(generateVal(2), generateVal(2)));
     }
 
     @Test

--- a/src/test/java/com/accelad/math/nilgiri/DoubleDoubleComplexTest.java
+++ b/src/test/java/com/accelad/math/nilgiri/DoubleDoubleComplexTest.java
@@ -1,25 +1,38 @@
 package com.accelad.math.nilgiri;
 
-import static org.junit.Assert.assertEquals;
-
+import com.accelad.math.doubledouble.DoubleDouble;
+import org.apfloat.Apcomplex;
+import org.apfloat.ApcomplexMath;
+import org.apfloat.Apfloat;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 public class DoubleDoubleComplexTest {
 
     @Test
     public void testInverse() throws Exception {
-        DoubleDoubleComplex expected = new DoubleDoubleComplex(2.0 / 13.0, -3.0 / 13.0);
+
+        DoubleDouble thirteen = DoubleDouble.fromString("13.0");
+        DoubleDouble expectedReal = DoubleDouble.TWO.divide(thirteen);
+        DoubleDouble minusThree = DoubleDouble.fromString("-3.0");
+        DoubleDouble expectedImaginary = minusThree.divide(thirteen);
+        DoubleDoubleComplex expected = new DoubleDoubleComplex(expectedReal, expectedImaginary);
 
         DoubleDoubleComplex ddc = new DoubleDoubleComplex(2, 3);
         DoubleDoubleComplex result = ddc.inverse();
 
-        assertEquals(expected.getReal(), result.getReal(), 1e-12);
-        assertEquals(expected.getImaginary(), result.getImaginary(), 1e-12);
+        assertEquals(expected, result);
     }
 
     @Test
     public void testDiv() throws Exception {
-        DoubleDoubleComplex expected = new DoubleDoubleComplex(8.0 / 5.0, -1.0 / 5.0);
+        DoubleDouble five = DoubleDouble.fromString("5.0");
+        DoubleDouble eight = DoubleDouble.fromString("8.0");
+        DoubleDouble minusOne = DoubleDouble.ONE.negate();
+        DoubleDouble expectedReal = eight.divide(five);
+        DoubleDouble expectedImaginary = minusOne.divide(five);
+        DoubleDoubleComplex expected = new DoubleDoubleComplex(expectedReal, expectedImaginary);
 
         DoubleDoubleComplex ddc1 = new DoubleDoubleComplex(2, 3);
         DoubleDoubleComplex ddc2 = new DoubleDoubleComplex(1, 2);
@@ -30,7 +43,9 @@ public class DoubleDoubleComplexTest {
 
     @Test
     public void testAbs() throws Exception {
-        DoubleDoubleComplex expected = new DoubleDoubleComplex(Math.sqrt(13.0), 0);
+        DoubleDouble expectedReal = DoubleDouble.fromString("13.0").sqrt();
+        DoubleDouble expectedImaginary = DoubleDouble.ZERO;
+        DoubleDoubleComplex expected = new DoubleDoubleComplex(expectedReal, expectedImaginary);
 
         DoubleDoubleComplex ddc1 = new DoubleDoubleComplex(2, 3);
         DoubleDoubleComplex result = ddc1.abs();
@@ -61,12 +76,21 @@ public class DoubleDoubleComplexTest {
 
     @Test
     public void testLog() throws Exception {
-        DoubleDoubleComplex expected = new DoubleDoubleComplex(1.282474678730, 0.982793723247);
+        Apcomplex arbitraryComplex = new Apcomplex(new Apfloat("2"), new Apfloat("3")).precision(31);
+        Apcomplex arbitraryResult = ApcomplexMath.log(arbitraryComplex);
+        String real = arbitraryResult.real().toString(true);
+        String imaginary = arbitraryResult.imag().toString(true);
 
-        DoubleDoubleComplex ddc1 = new DoubleDoubleComplex(2, 3);
-        DoubleDoubleComplex result = ddc1.log();
+        DoubleDouble expectedReal = DoubleDouble.fromString(real);
+        DoubleDouble expectedImaginary = DoubleDouble.fromString(imaginary);
+        DoubleDoubleComplex expected = new DoubleDoubleComplex(expectedReal, expectedImaginary);
 
-        assertEquals(expected, result);
+        DoubleDouble three = DoubleDouble.fromString("3");
+        DoubleDouble two = DoubleDouble.TWO;
+        DoubleDoubleComplex complexValue = new DoubleDoubleComplex(two, three);
+        DoubleDoubleComplex actual = complexValue.log();
+
+        assertEquals(expected, actual);
     }
 
     @Test
@@ -96,7 +120,7 @@ public class DoubleDoubleComplexTest {
         DoubleDoubleComplex expected = new DoubleDoubleComplex(8, 12);
 
         DoubleDoubleComplex ddc1 = new DoubleDoubleComplex(2, 3);
-        DoubleDoubleComplex result = ddc1.mul(4l);
+        DoubleDoubleComplex result = ddc1.mul(4);
 
         assertEquals(expected, result);
     }
@@ -113,34 +137,63 @@ public class DoubleDoubleComplexTest {
 
     @Test
     public void testCos() {
-        DoubleDoubleComplex expected = new DoubleDoubleComplex(-4.189625690968, -9.109227893755);
+        Apcomplex arbitraryComplex = new Apcomplex(new Apfloat("2"), new Apfloat("3")).precision(31);
+        Apcomplex arbitraryResult = ApcomplexMath.cos(arbitraryComplex);
+        String real = arbitraryResult.real().toString(true);
+        String imaginary = arbitraryResult.imag().toString(true);
 
-        DoubleDoubleComplex actual = new DoubleDoubleComplex(2, 3).cos();
+        DoubleDouble expectedReal = DoubleDouble.fromString(real);
+        DoubleDouble expectedImaginary = DoubleDouble.fromString(imaginary);
+        DoubleDoubleComplex expected = new DoubleDoubleComplex(expectedReal, expectedImaginary);
+
+        DoubleDoubleComplex actual = new DoubleDoubleComplex(DoubleDouble.fromString("2"), DoubleDouble.fromString("3")).cos();
 
         assertEquals(expected, actual);
     }
 
     @Test
     public void testSin() {
-        DoubleDoubleComplex expected = new DoubleDoubleComplex(9.154499146911, -4.168906959966);
+        Apcomplex arbitraryComplex = new Apcomplex(new Apfloat("2"), new Apfloat("3")).precision(31);
+        Apcomplex arbitraryResult = ApcomplexMath.sin(arbitraryComplex);
+        String real = arbitraryResult.real().toString(true);
+        String imaginary = arbitraryResult.imag().toString(true);
 
-        DoubleDoubleComplex actual = new DoubleDoubleComplex(2, 3).sin();
+        DoubleDouble expectedReal = DoubleDouble.fromString(real);
+        DoubleDouble expectedImaginary = DoubleDouble.fromString(imaginary);
+        DoubleDoubleComplex expected = new DoubleDoubleComplex(expectedReal, expectedImaginary);
+
+        DoubleDoubleComplex actual = new DoubleDoubleComplex(DoubleDouble.fromString("2"), DoubleDouble.fromString("3")).sin();
 
         assertEquals(expected, actual);
     }
 
     @Test
     public void testTan() {
-        DoubleDoubleComplex expected = new DoubleDoubleComplex(-0.003764025641, 1.003238627353);
+        Apcomplex arbitraryComplex = new Apcomplex(new Apfloat("2"), new Apfloat("3")).precision(31);
+        Apcomplex arbitraryResult = ApcomplexMath.tan(arbitraryComplex);
+        String real = arbitraryResult.real().toString(true);
+        String imaginary = arbitraryResult.imag().toString(true);
 
-        DoubleDoubleComplex actual = new DoubleDoubleComplex(2, 3).tan();
+        DoubleDouble expectedReal = DoubleDouble.fromString(real);
+        DoubleDouble expectedImaginary = DoubleDouble.fromString(imaginary);
+        DoubleDoubleComplex expected = new DoubleDoubleComplex(expectedReal, expectedImaginary);
+
+        DoubleDoubleComplex actual = new DoubleDoubleComplex(DoubleDouble.fromString("2"), DoubleDouble.fromString("3")).tan();
 
         assertEquals(expected, actual);
     }
 
     @Test
     public void testPowComplexExponent() throws Exception {
-        DoubleDoubleComplex expected = new DoubleDoubleComplex(-3.098975623228, 1.179587754377);
+        Apcomplex arbitraryComplex = new Apcomplex(new Apfloat("2", 31), new Apfloat("3", 31));
+        Apcomplex exponent = new Apcomplex(new Apfloat("4", 31), new Apfloat("4", 31));
+        Apcomplex arbitraryResult = ApcomplexMath.pow(arbitraryComplex, exponent);
+        String real = arbitraryResult.real().toString(true);
+        String imaginary = arbitraryResult.imag().toString(true);
+
+        DoubleDouble expectedReal = DoubleDouble.fromString(real);
+        DoubleDouble expectedImaginary = DoubleDouble.fromString(imaginary);
+        DoubleDoubleComplex expected = new DoubleDoubleComplex(expectedReal, expectedImaginary);
 
         DoubleDoubleComplex actual = new DoubleDoubleComplex(2, 3)
                 .pow(new DoubleDoubleComplex(4, 4));


### PR DESCRIPTION
When the doubledouble was low ( before 1E-12) the equality test was always returning true.
Moreover the equals was not checking the sum of hi+lo.

Fixing this bug raised some issues in term of precision in the existing tests.
Acceptance values in the tests were defined for standard double: that mean loss of accuracy.
Fixing this lack of accuracy was shown a loss of accuracy in the complex log calculation.

Loss of precision was also introduced in the factory test as we were only using standard double precision with the val(...) method. We had to introduce one method to take in account string representation which allow to keep precision.

For some test the apfloat library was been introduced to compute the expected complex values with arbitraty precision (higher than the 30 digits precision of DoubleDouble)