### PR TITLE
Fix infinite loop in pow function

### DIFF
--- a/src/test/java/com/accelad/math/doubledouble/DoubleDoubleTest.java
+++ b/src/test/java/com/accelad/math/doubledouble/DoubleDoubleTest.java
@@ -28,6 +28,48 @@ public class DoubleDoubleTest {
         assertThat(givenValuePoweredByThree, is(DoubleDouble.fromString("1.728")));
     }
 
+    @Test
+    public void should_return_nan_when_log_too_high() {
+        double notComputableMaxValue = (Double.MAX_VALUE / DoubleDouble.SPLIT) * DoubleDouble.E.doubleValue();
+        DoubleDouble givenValue = DoubleDouble.fromOneDouble(notComputableMaxValue);
+
+        DoubleDouble log = givenValue.log();
+
+        assertTrue(log.isNaN());
+    }
+
+    @Test
+    public void should_return_value_when_log_the_max_value_acceptable() {
+        double split = DoubleDouble.SPLIT + 1;
+        double maxComputableValue = (Double.MAX_VALUE / split) * DoubleDouble.E.doubleValue();
+        DoubleDouble givenValue = DoubleDouble.fromOneDouble(maxComputableValue);
+
+        DoubleDouble log = givenValue.log();
+
+        assertFalse(log.isNaN());
+    }
+
+    @Test
+    public void should_return_nan_when_pow_too_high() {
+        double notComputableMaxValue = (Double.MAX_VALUE / DoubleDouble.SPLIT) * DoubleDouble.E.doubleValue();
+        DoubleDouble givenValue = DoubleDouble.fromOneDouble(notComputableMaxValue);
+
+        DoubleDouble log = givenValue.pow(DoubleDouble.fromOneDouble(2));
+
+        assertTrue(log.isNaN());
+    }
+
+    @Test
+    public void should_return_value_when_pow_the_max_value_acceptable() {
+        double split = DoubleDouble.SPLIT + 1;
+        double maxComputableValue = (Double.MAX_VALUE / split) * DoubleDouble.E.doubleValue();
+        DoubleDouble givenValue = DoubleDouble.fromOneDouble(maxComputableValue);
+
+        DoubleDouble log = givenValue.pow(DoubleDouble.fromOneDouble(2));
+
+        assertFalse(log.isNaN());
+    }
+
     @Test(expected = ArithmeticException.class)
     public void should_throw_an_exception_when_computing_atan2_with_x_and_y_equals_zero() throws Exception {
         DoubleDouble x = DoubleDouble.ZERO;


### PR DESCRIPTION
This is done in two time:
1. Checking the value in log function: log cannot be apply to a too
   high value due to the division in log. In this case we return NaN.
2. Pow function use exp function instead of his own implementation.
   In exp function the greater value acceptable is checked.